### PR TITLE
전체 레이아웃 및 PointModal 디자인

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,3 +3,19 @@
   padding: 0;
   margin: 0;
 }
+
+body {
+  display: flex;
+  justify-content: center;
+  width: 100wh;
+  height: 100vh;
+}
+
+#root-layout {
+  width: 414px;
+  height: 100%;
+}
+
+input {
+  background-color: transparent;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body>{children}</body>
+      <body>
+        <main id="root-layout">{children}</main>
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
 import KaKaoMap from '@/components/KaKaoMap';
-import PointModal from '@/components/PointModal';
+import PointInput from '@/components/PointInput';
 
 export default function Home() {
   return (
     <>
-      <PointModal />
+      <PointInput />
       <KaKaoMap />
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,11 @@
 import KaKaoMap from '@/components/KaKaoMap';
+import PointModal from '@/components/PointModal';
 
 export default function Home() {
-  return <KaKaoMap />;
+  return (
+    <>
+      <PointModal />
+      <KaKaoMap />
+    </>
+  );
 }

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -26,5 +26,13 @@ export default function KaKaoMap() {
     });
   }, [mapLoaded]);
 
-  return <div id="map" style={{ width: '500px', height: '400px' }}></div>;
+  return (
+    <div
+      id="map"
+      style={{
+        width: '100%',
+        height: '87%',
+      }}
+    ></div>
+  );
 }

--- a/src/components/PointInput.tsx
+++ b/src/components/PointInput.tsx
@@ -2,7 +2,7 @@
 
 import { Box, TextField } from '@mui/material';
 
-export default function PointModal() {
+export default function PointInput() {
   return (
     <Box
       sx={{

--- a/src/components/PointModal.tsx
+++ b/src/components/PointModal.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Box, TextField } from '@mui/material';
+
+export default function PointModal() {
+  return (
+    <Box
+      sx={{
+        margin: '10px 0',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '10px',
+      }}
+    >
+      <TextField
+        fullWidth
+        label="출발지"
+        defaultValue="출발지 간단 도로명주소"
+        variant="filled"
+        size="small"
+      />
+      <TextField
+        fullWidth
+        label="도착지"
+        defaultValue="도착지 간단 도로명주소"
+        variant="filled"
+        size="small"
+      />
+    </Box>
+  );
+}


### PR DESCRIPTION
# 작업 내용

- [x] 전체 레이아웃 작업
- [x] PointModal 디자인

![image](https://github.com/Team-Router/client/assets/75886763/a90cd051-a9ee-4ea6-97f9-b8980ac8fd96)


# 관련 이슈

- PointModal의 디자인을 개선하고 싶으시면 언제나 환영입니다.
- 레이아웃의 가로길이(414px)는 Bidmarket 프로젝트의 디자인을 참고했습니다.
