### PR TITLE
카카오 맵 현재 위도 경도와 주소 변환 구현

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,17 @@
+'use client';
+
+import { useState } from 'react';
+
 import KaKaoMap from '@/components/KaKaoMap';
 import PointInput from '@/components/PointInput';
 
 export default function Home() {
+  const [startPoint, setStartPoint] = useState('');
+
   return (
     <>
-      <PointInput />
-      <KaKaoMap />
+      <PointInput startPoint={startPoint} />
+      <KaKaoMap setStartPoint={setStartPoint} />
     </>
   );
 }

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -2,12 +2,14 @@
 
 import React, { useEffect, useState } from 'react';
 
+import { displayMarker } from '@/utils/displayMarker';
+
 export default function KaKaoMap() {
   const [mapLoaded, setMapLoaded] = useState(false);
 
   useEffect(() => {
     const $script = document.createElement('script');
-    $script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY}&autoload=false`;
+    $script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY}&autoload=false&libraries=services`;
     $script.addEventListener('load', () => setMapLoaded(true));
     document.head.appendChild($script);
   }, []);
@@ -23,6 +25,41 @@ export default function KaKaoMap() {
       };
 
       const map = new kakao.maps.Map(container, options);
+      const geocoder = new kakao.maps.services.Geocoder();
+
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition((position) => {
+          const lat = position.coords.latitude;
+          const lon = position.coords.longitude;
+
+          const locPosition = new kakao.maps.LatLng(lat, lon);
+          const message = '<div styled="padding:5px">출발</div>';
+
+          displayMarker(map, locPosition, message);
+
+          const callback = (
+            result: { [key: string]: any },
+            status: kakao.maps.services.Status
+          ) => {
+            if (status === kakao.maps.services.Status.OK) {
+              console.log(result[0].address.address_name);
+            } else {
+              console.log('현재 위치의 주소를 가져올 수 없습니다.');
+            }
+          };
+
+          geocoder.coord2Address(
+            locPosition.getLng(),
+            locPosition.getLat(),
+            callback
+          );
+        });
+      } else {
+        const locPosition = new kakao.maps.LatLng(33.450701, 126.570667),
+          message = 'geolocation을 사용할수 없어요..';
+
+        displayMarker(map, locPosition, message);
+      }
     });
   }, [mapLoaded]);
 

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -55,8 +55,8 @@ export default function KaKaoMap() {
           );
         });
       } else {
-        const locPosition = new kakao.maps.LatLng(33.450701, 126.570667),
-          message = 'geolocation을 사용할수 없어요..';
+        const locPosition = new kakao.maps.LatLng(33.450701, 126.570667);
+        const message = 'geolocation을 사용할수 없어요..';
 
         displayMarker(map, locPosition, message);
       }

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -4,7 +4,11 @@ import React, { useEffect, useState } from 'react';
 
 import { displayMarker } from '@/utils/displayMarker';
 
-export default function KaKaoMap() {
+interface KaKaoMapProps {
+  setStartPoint: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export default function KaKaoMap({ setStartPoint }: KaKaoMapProps) {
   const [mapLoaded, setMapLoaded] = useState(false);
 
   useEffect(() => {
@@ -42,7 +46,7 @@ export default function KaKaoMap() {
             status: kakao.maps.services.Status
           ) => {
             if (status === kakao.maps.services.Status.OK) {
-              console.log(result[0].address.address_name);
+              setStartPoint(result[0].address.address_name);
             } else {
               console.log('현재 위치의 주소를 가져올 수 없습니다.');
             }

--- a/src/components/PointInput.tsx
+++ b/src/components/PointInput.tsx
@@ -2,7 +2,7 @@
 
 import { Box, TextField } from '@mui/material';
 
-export default function PointInput() {
+export default function PointInput({ startPoint }: { startPoint: string }) {
   return (
     <Box
       sx={{
@@ -15,7 +15,7 @@ export default function PointInput() {
       <TextField
         fullWidth
         label="출발지"
-        defaultValue="출발지 간단 도로명주소"
+        defaultValue={startPoint ? startPoint : '출발지 간단 도로명주소'}
         variant="filled"
         size="small"
       />

--- a/src/utils/displayMarker.ts
+++ b/src/utils/displayMarker.ts
@@ -1,0 +1,22 @@
+export const displayMarker = (
+  map: kakao.maps.Map,
+  locPosition: kakao.maps.LatLng,
+  message: string
+) => {
+  const marker = new kakao.maps.Marker({
+    map: map,
+    position: locPosition,
+  });
+
+  const iwContent = message;
+  const iwRemoveable = true;
+
+  const infowindow = new kakao.maps.InfoWindow({
+    content: iwContent,
+    removable: iwRemoveable,
+  });
+
+  infowindow.open(map, marker);
+
+  map.setCenter(locPosition);
+};


### PR DESCRIPTION
<!-- 제목 : [작업 제목] -->

# 작업 내용
- [x] 카카오 맵 현재 위도 경도와 주소 변환 구현
- [x] displayMarker util함수로 마커 구현
- [x] Input 출발지 defaultValue에 기본 주소 적용

# 관련 이슈
- 이슈: 처음 지도 로드 시 현재 위치를 받아오는 동안에 로딩 시간이 조금 김 -> 추후 해결해야할 것 같습니다.
 + 출발지 Input적용도 로딩 시간이 깁니당

- 앞으로 구현해야할 기능
  - [x] 콘솔로 현재 주소 찍은 부분을 상단 Input로 이동
- 참고한 카카오 맵 링크
  - [좌표로 주소를 얻어내기](https://apis.map.kakao.com/web/sample/coord2addr/)
  - [geolocation으로 마커 표시하기](https://apis.map.kakao.com/web/sample/geolocationMarker/)
