### PR TITLE
카카오맵 Script 로드 next/script 태그로 리팩토링

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,25 +1,17 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import KaKaoMap from '@/components/KaKaoMap';
 import PointInput from '@/components/PointInput';
 
 export default function Home() {
-  const [mapLoaded, setMapLoaded] = useState(false);
   const [startPoint, setStartPoint] = useState('');
-
-  useEffect(() => {
-    const $script = document.createElement('script');
-    $script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY}&libraries=services&autoload=false`;
-    $script.addEventListener('load', () => setMapLoaded(true));
-    document.head.appendChild($script);
-  }, []);
 
   return (
     <>
       <PointInput startPoint={startPoint} />
-      {mapLoaded && <KaKaoMap setStartPoint={setStartPoint} />}
+      <KaKaoMap setStartPoint={setStartPoint} />
     </>
   );
 }

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useAtom } from 'jotai';
-import React, { useEffect } from 'react';
+import Script from 'next/script';
+import React, { useEffect, useRef } from 'react';
 
 import { useGeolocation } from '@/hooks/useGeolocation';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
@@ -13,21 +14,10 @@ interface KaKaoMapProps {
 
 export default function KaKaoMap({ setStartPoint }: KaKaoMapProps) {
   const [map, setMap] = useAtom(mapAtom);
+  const mapRef = useRef<HTMLDivElement>(null);
 
   const { displayMarker, displayInfoWindow } = useKakaoMap();
   const { lat, lon, initPosition } = useGeolocation();
-
-  useEffect(() => {
-    kakao.maps.load(() => {
-      const container = document.getElementById('map') as HTMLElement;
-      initPosition();
-      const options = {
-        center: new kakao.maps.LatLng(lat, lon),
-        level: 3,
-      };
-      setMap(new kakao.maps.Map(container, options));
-    });
-  }, [lat, lon, setMap, initPosition]);
 
   useEffect(() => {
     displayMarker(lat, lon);
@@ -46,12 +36,30 @@ export default function KaKaoMap({ setStartPoint }: KaKaoMapProps) {
   }, [map, displayInfoWindow]);
 
   return (
-    <div
-      id="map"
-      style={{
-        width: '100%',
-        height: '87%',
-      }}
-    ></div>
+    <>
+      <div
+        ref={mapRef}
+        id="kakao-map"
+        style={{
+          width: '100%',
+          height: '87%',
+        }}
+      ></div>
+      <Script
+        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY}&libraries=services&autoload=false`}
+        onReady={() => {
+          kakao.maps.load(() => {
+            initPosition();
+            const options = {
+              center: new kakao.maps.LatLng(lat, lon),
+              level: 3,
+            };
+            setMap(
+              new kakao.maps.Map(mapRef.current as HTMLDivElement, options)
+            );
+          });
+        }}
+      />
+    </>
   );
 }


### PR DESCRIPTION
<!-- 제목 : [작업 제목] -->

# 작업 내용
- [x] 카카오맵 Script 로드 next/script 태그로 리팩토링

# 관련 이슈
- [next13 공식문서 next/script docs](https://nextjs.org/docs/app/api-reference/components/script#onready)
- 지금처럼 script로 변경했을 때에는 useEffect를 사용하지 않아도 되는 장점이 있습니다 :)

# 중점적으로 봐줬으면 하는 부분
- 지금처럼 변경하는 것이 좋을지 확실히 확인 부탁드립니당 :)
