### PR TITLE
infoWindow의 이벤트에 따라 화면 이동 및 주소 나타내기

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,13 @@
 'use client';
 
-import { useState } from 'react';
-
+import AddressInput from '@/components/AddressInput';
 import KaKaoMap from '@/components/KaKaoMap';
-import PointInput from '@/components/PointInput';
 
 export default function Home() {
-  const [startPoint, setStartPoint] = useState('');
-
   return (
     <>
-      <PointInput startPoint={startPoint} />
-      <KaKaoMap setStartPoint={setStartPoint} />
+      <AddressInput />
+      <KaKaoMap />
     </>
   );
 }

--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -2,7 +2,11 @@
 
 import { Box, TextField } from '@mui/material';
 
-export default function PointInput({ startPoint }: { startPoint: string }) {
+import { useKakaoMap } from '@/hooks/useKakaoMap';
+
+export default function PointInput() {
+  const { startAddress, endAddress } = useKakaoMap();
+
   return (
     <Box
       sx={{
@@ -15,14 +19,14 @@ export default function PointInput({ startPoint }: { startPoint: string }) {
       <TextField
         fullWidth
         label="출발지"
-        defaultValue={startPoint ? startPoint : '출발지 간단 도로명주소'}
+        defaultValue={startAddress ? startAddress : '출발지 간단 도로명주소'}
         variant="filled"
         size="small"
       />
       <TextField
         fullWidth
         label="도착지"
-        defaultValue="도착지 간단 도로명주소"
+        defaultValue={endAddress ? endAddress : '도착지 간단 도로명주소'}
         variant="filled"
         size="small"
       />

--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { Box, TextField } from '@mui/material';
+import { useAtomValue } from 'jotai';
 
-import { useKakaoMap } from '@/hooks/useKakaoMap';
+import { addressAtom } from '@/store/atom';
 
 export default function PointInput() {
-  const { startAddress, endAddress } = useKakaoMap();
+  const address = useAtomValue(addressAtom);
 
   return (
     <Box
@@ -17,18 +18,14 @@ export default function PointInput() {
       }}
     >
       <TextField
-        fullWidth
-        label="출발지"
-        defaultValue={startAddress ? startAddress : '출발지 간단 도로명주소'}
-        variant="filled"
         size="small"
+        fullWidth
+        defaultValue={address.start || '출발지'}
       />
       <TextField
-        fullWidth
-        label="도착지"
-        defaultValue={endAddress ? endAddress : '도착지 간단 도로명주소'}
-        variant="filled"
         size="small"
+        fullWidth
+        defaultValue={address.end || '도착지'}
       />
     </Box>
   );

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -24,15 +24,15 @@ export default function KakaoMap() {
       return;
     }
 
-    const handler = (mouseEvent: kakao.maps.event.MouseEvent) => {
+    const onClickMap = (mouseEvent: kakao.maps.event.MouseEvent) => {
       const latlng = mouseEvent.latLng;
       displayInfoWindow(latlng.getLat(), latlng.getLng());
     };
 
-    kakao.maps.event.addListener(map, 'click', handler);
+    kakao.maps.event.addListener(map, 'click', onClickMap);
     kakao.maps.event.addListener(map, 'dragend', closeInfoWindow);
     return () => {
-      kakao.maps.event.removeListener(map, 'click', handler);
+      kakao.maps.event.removeListener(map, 'click', onClickMap);
       kakao.maps.event.removeListener(map, 'dragend', closeInfoWindow);
     };
   }, [map, displayInfoWindow, closeInfoWindow]);

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -17,7 +17,7 @@ export default function KakaoMap() {
 
   useEffect(() => {
     displayMarker(lat, lon, 'start');
-  }, [lat, lon, map, displayMarker]);
+  }, [lat, lon, displayMarker]);
 
   useEffect(() => {
     if (!map) {

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -16,21 +16,5 @@ export function useGeolocation() {
     }
   }, []);
 
-  const getAddress = (lat: number, lon: number) => {
-    const geocoder = new kakao.maps.services.Geocoder();
-    const callback = (
-      result: { [key: string]: any },
-      status: kakao.maps.services.Status
-    ) => {
-      if (status === kakao.maps.services.Status.OK) {
-        return result[0].address.address_name;
-      } else {
-        alert('현재 위치의 주소를 가져올 수 없습니다.');
-      }
-    };
-
-    geocoder.coord2Address(lat, lon, callback);
-  };
-
-  return { lat, lon, initPosition, getAddress };
+  return { lat, lon, initPosition };
 }

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -1,20 +1,28 @@
 import { useCallback, useState } from 'react';
 
+import { useKakaoMap } from './useKakaoMap';
+
 export function useGeolocation() {
   const [lat, setLat] = useState(33.450701);
   const [lon, setLon] = useState(126.570667);
+  const { changeAddress } = useKakaoMap();
 
   const initPosition = useCallback(() => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition((position) => {
         setLat(position.coords.latitude);
         setLon(position.coords.longitude);
+        changeAddress(
+          position.coords.latitude,
+          position.coords.longitude,
+          'start'
+        );
       });
     } else {
       console.log('geolocation을 사용할수 없어요..');
       alert('geolocation을 사용할수 없어요..');
     }
-  }, []);
+  }, [changeAddress]);
 
   return { lat, lon, initPosition };
 }

--- a/src/hooks/useKakaoMap.ts
+++ b/src/hooks/useKakaoMap.ts
@@ -1,15 +1,14 @@
-import { useAtomValue } from 'jotai';
-import { useCallback, useRef, useState } from 'react';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback, useRef } from 'react';
 
-import { mapAtom } from '@/store/atom';
+import { addressAtom, mapAtom } from '@/store/atom';
 import { getInfoWindowElement } from '@/utils/infoWindowElement';
 
 type pointType = 'start' | 'end';
 
 export function useKakaoMap() {
   const map = useAtomValue(mapAtom);
-  const [startAddress, setStartAddress] = useState('');
-  const [endAddress, setEndAddress] = useState('');
+  const [address, setAddress] = useAtom(addressAtom);
   const startMarker = useRef<kakao.maps.Marker>();
   const endMarker = useRef<kakao.maps.Marker>();
   const infoWindow = useRef<kakao.maps.InfoWindow | null>();
@@ -81,9 +80,9 @@ export function useKakaoMap() {
     const geocoder = new kakao.maps.services.Geocoder();
     const callback = (result: any, status: kakao.maps.services.Status) => {
       if (status === kakao.maps.services.Status.OK) {
-        const address = result[0].address.address_name;
-        pointType === 'start' && setStartAddress(address);
-        pointType === 'end' && setEndAddress(address);
+        const newAddress = result[0].address.address_name;
+        pointType === 'start' && setAddress({ ...address, start: newAddress });
+        pointType === 'end' && setAddress({ ...address, end: newAddress });
       } else {
         alert('현재 위치의 주소를 가져올 수 없습니다.');
       }
@@ -93,8 +92,6 @@ export function useKakaoMap() {
   };
 
   return {
-    startAddress,
-    endAddress,
     getPosition,
     displayMarker,
     displayInfoWindow,

--- a/src/hooks/useKakaoMap.ts
+++ b/src/hooks/useKakaoMap.ts
@@ -96,5 +96,6 @@ export function useKakaoMap() {
     displayMarker,
     displayInfoWindow,
     closeInfoWindow,
+    changeAddress,
   };
 }

--- a/src/hooks/useKakaoMap.ts
+++ b/src/hooks/useKakaoMap.ts
@@ -1,5 +1,5 @@
 import { useAtomValue } from 'jotai';
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import { mapAtom } from '@/store/atom';
 import { getInfoWindowElement } from '@/utils/infoWindowElement';
@@ -18,27 +18,30 @@ export function useKakaoMap() {
     return new kakao.maps.LatLng(lat, lon);
   };
 
-  const displayMarker = (lat: number, lon: number, pointType: pointType) => {
-    if (!map) {
-      return;
-    }
+  const displayMarker = useCallback(
+    (lat: number, lon: number, pointType: pointType) => {
+      if (!map) {
+        return;
+      }
 
-    const locPosition = getPosition(lat, lon);
-    const marker = new kakao.maps.Marker({
-      map: map,
-      position: locPosition,
-    });
-    if (pointType === 'start') {
-      startMarker.current && startMarker.current.setMap(null);
-      startMarker.current = marker;
-    }
-    if (pointType === 'end') {
-      endMarker.current && endMarker.current.setMap(null);
-      endMarker.current = marker;
-    }
+      const locPosition = getPosition(lat, lon);
+      const marker = new kakao.maps.Marker({
+        map: map,
+        position: locPosition,
+      });
+      if (pointType === 'start') {
+        startMarker.current && startMarker.current.setMap(null);
+        startMarker.current = marker;
+      }
+      if (pointType === 'end') {
+        endMarker.current && endMarker.current.setMap(null);
+        endMarker.current = marker;
+      }
 
-    map.panTo(locPosition);
-  };
+      map.panTo(locPosition);
+    },
+    [map]
+  );
 
   const closeInfoWindow = () => {
     if (infoWindow.current) {
@@ -79,7 +82,6 @@ export function useKakaoMap() {
     const callback = (result: any, status: kakao.maps.services.Status) => {
       if (status === kakao.maps.services.Status.OK) {
         const address = result[0].address.address_name;
-        console.log(address);
         pointType === 'start' && setStartAddress(address);
         pointType === 'end' && setEndAddress(address);
       } else {

--- a/src/store/atom.ts
+++ b/src/store/atom.ts
@@ -1,3 +1,8 @@
 import { atom } from 'jotai';
 
 export const mapAtom = atom<kakao.maps.Map | null>(null);
+
+export const addressAtom = atom<{ start: string; end: string }>({
+  start: '',
+  end: '',
+});

--- a/src/utils/infoWindowElement.ts
+++ b/src/utils/infoWindowElement.ts
@@ -1,0 +1,18 @@
+type handler = () => void;
+
+const getButtonElement = (text: string, handler: handler) => {
+  const $button = document.createElement('button');
+  $button.innerText = text;
+  $button.addEventListener('click', handler);
+  return $button;
+};
+
+export const getInfoWindowElement = (
+  startHandler: handler,
+  endHandler: handler
+) => {
+  const $div = document.createElement('div');
+  $div.appendChild(getButtonElement('출발', startHandler));
+  $div.appendChild(getButtonElement('도착', endHandler));
+  return $div;
+};


### PR DESCRIPTION
# 작업 내용

- [x] map 2개 뜨는 버그 해결
   - 초기 상태에서 지도에 마크2개가 존재해야 정상
- [x] infoWindow 생성
   - infoWindow Element 생성하는 유틸 함수 작성
   - 지도에 infoWindow는 1개만 보이도록 구현
      - 지도 클릭시 기존 infoWindow 제거하고 새로운 infoWindow 생성
      - 지도 드래그시 기존 infoWindow 제거
   - infoWindow의 출발, 도착 버튼 이벤트에 따라 다음 동작 반영
      - 마크 생성 및 옮기기
      - 화면 이동
      - 주소 가져오기

# 관련 이슈

- [x] 아직 구현 미완성입니다. 완성 후 PR review 부탁드립니다.
   - infoWindow의 버튼 이벤트로 부터 가져온 주소를 AddressInput 컴포넌트에 반영을 해야 합니다.
   - (`6/12` @sukyeongh ) 해결 완로
   - 초기 현위치 주소 렌더링 추가 (하단 영상 as-is, to-be)

   - https://github.com/Team-Router/client/assets/75886763/f7c8d3dc-e14d-48bf-8fe5-8dc36a04f655

   - https://github.com/Team-Router/client/assets/75886763/a2f8ba92-c5bb-45d5-9f4c-ad4cd430ee2a

