### PR TITLE
공통 API, postDirection API 구현 / 모든 주소 작성시 API 호출

### DIFF
--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,0 +1,32 @@
+interface Param {
+  [key: string]: any;
+}
+
+const commonFetch = (url: string, options?: RequestInit) => {
+  return fetch(`${process.env.NEXT_PUBLIC_BASE_URL}${url}`, { ...options })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP error: The status is ${response.status}`);
+      }
+      return response.json();
+    })
+    .catch((err) => {
+      console.log(err.message);
+    });
+};
+
+export const getFetch = (url: string, options?: RequestInit) => {
+  return commonFetch(url, { ...options, mode: 'cors' });
+};
+
+export const postFetch = (url: string, param: Param, options?: RequestInit) => {
+  return commonFetch(url, {
+    ...options,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    mode: 'cors',
+    body: JSON.stringify(param),
+  });
+};

--- a/src/api/direction.ts
+++ b/src/api/direction.ts
@@ -1,0 +1,14 @@
+import { PostDirectionResponse } from '@/types/direction';
+
+import { postFetch } from './common';
+
+interface PostDirectionParam {
+  startLatitude: number;
+  startLongitude: number;
+  endLatitude: number;
+  endLongitude: number;
+}
+
+export const postDirectionAPI = (param: PostDirectionParam) => {
+  return postFetch('/route/cycle', param) as Promise<PostDirectionResponse>;
+};

--- a/src/api/direction.ts
+++ b/src/api/direction.ts
@@ -9,6 +9,6 @@ interface PostDirectionParam {
   endLongitude: number;
 }
 
-export const postDirectionAPI = (param: PostDirectionParam) => {
+export const getDirectionBySelectedLocation = (param: PostDirectionParam) => {
   return postFetch('/route/cycle', param) as Promise<PostDirectionResponse>;
 };

--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -21,11 +21,13 @@ export default function PointInput() {
         size="small"
         fullWidth
         defaultValue={address.start || '출발지'}
+        disabled
       />
       <TextField
         size="small"
         fullWidth
         defaultValue={address.end || '도착지'}
+        disabled
       />
     </Box>
   );

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -4,7 +4,7 @@ import { useAtom, useAtomValue } from 'jotai';
 import Script from 'next/script';
 import React, { useCallback, useEffect, useRef } from 'react';
 
-import { postDirectionAPI } from '@/api/direction';
+import { getDirectionBySelectedLocation } from '@/api/direction';
 import { useGeolocation } from '@/hooks/useGeolocation';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
 import { addressAtom, locationAtom, mapAtom } from '@/store/atom';
@@ -41,7 +41,7 @@ export default function KakaoMap() {
   }, [map, displayInfoWindow, closeInfoWindow]);
 
   const postDirection = useCallback(async () => {
-    const response = await postDirectionAPI(location);
+    const response = await getDirectionBySelectedLocation(location);
     console.log(response);
   }, [location]);
 

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -12,16 +12,13 @@ export function useGeolocation() {
   const initPosition = useCallback(() => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition((position) => {
+        const { latitude, longitude } = position.coords;
         setLocation({
           ...location,
-          startLatitude: position.coords.latitude,
-          startLongitude: position.coords.longitude,
+          startLatitude: latitude,
+          startLongitude: longitude,
         });
-        changeAddress(
-          position.coords.latitude,
-          position.coords.longitude,
-          'start'
-        );
+        changeAddress(latitude, longitude, 'start');
       });
     } else {
       alert('현위치를 알 수 없습니다.');

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -1,17 +1,22 @@
-import { useCallback, useState } from 'react';
+import { useAtom } from 'jotai';
+import { useCallback } from 'react';
+
+import { locationAtom } from '@/store/atom';
 
 import { useKakaoMap } from './useKakaoMap';
 
 export function useGeolocation() {
-  const [lat, setLat] = useState(33.450701);
-  const [lon, setLon] = useState(126.570667);
+  const [location, setLocation] = useAtom(locationAtom);
   const { changeAddress } = useKakaoMap();
 
   const initPosition = useCallback(() => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition((position) => {
-        setLat(position.coords.latitude);
-        setLon(position.coords.longitude);
+        setLocation({
+          ...location,
+          startLatitude: position.coords.latitude,
+          startLongitude: position.coords.longitude,
+        });
         changeAddress(
           position.coords.latitude,
           position.coords.longitude,
@@ -19,10 +24,9 @@ export function useGeolocation() {
         );
       });
     } else {
-      console.log('geolocation을 사용할수 없어요..');
-      alert('geolocation을 사용할수 없어요..');
+      alert('현위치를 알 수 없습니다.');
     }
-  }, [changeAddress]);
+  }, [changeAddress, location, setLocation]);
 
-  return { lat, lon, initPosition };
+  return { initPosition };
 }

--- a/src/hooks/useKakaoMap.ts
+++ b/src/hooks/useKakaoMap.ts
@@ -1,7 +1,7 @@
 import { useAtom, useAtomValue } from 'jotai';
 import { useCallback, useRef } from 'react';
 
-import { addressAtom, mapAtom } from '@/store/atom';
+import { addressAtom, locationAtom, mapAtom } from '@/store/atom';
 import { getInfoWindowElement } from '@/utils/infoWindowElement';
 
 type pointType = 'start' | 'end';
@@ -9,6 +9,7 @@ type pointType = 'start' | 'end';
 export function useKakaoMap() {
   const map = useAtomValue(mapAtom);
   const [address, setAddress] = useAtom(addressAtom);
+  const [location, setLocation] = useAtom(locationAtom);
   const startMarker = useRef<kakao.maps.Marker>();
   const endMarker = useRef<kakao.maps.Marker>();
   const infoWindow = useRef<kakao.maps.InfoWindow | null>();
@@ -29,11 +30,11 @@ export function useKakaoMap() {
         position: locPosition,
       });
       if (pointType === 'start') {
-        startMarker.current && startMarker.current.setMap(null);
+        startMarker.current?.setMap(null);
         startMarker.current = marker;
       }
       if (pointType === 'end') {
-        endMarker.current && endMarker.current.setMap(null);
+        endMarker.current?.setMap(null);
         endMarker.current = marker;
       }
 
@@ -60,6 +61,10 @@ export function useKakaoMap() {
         changeAddress(lat, lon, pointType);
         displayMarker(lat, lon, pointType);
         closeInfoWindow();
+        pointType === 'start' &&
+          setLocation({ ...location, startLatitude: lat, startLongitude: lon });
+        pointType === 'end' &&
+          setLocation({ ...location, endLatitude: lat, endLongitude: lon });
       };
     };
 

--- a/src/store/atom.ts
+++ b/src/store/atom.ts
@@ -6,3 +6,15 @@ export const addressAtom = atom<{ start: string; end: string }>({
   start: '',
   end: '',
 });
+
+export const locationAtom = atom<{
+  startLatitude: number;
+  startLongitude: number;
+  endLatitude: number;
+  endLongitude: number;
+}>({
+  startLatitude: 33.450701,
+  startLongitude: 126.570667,
+  endLatitude: 33.450701,
+  endLongitude: 126.570667,
+});

--- a/src/types/direction.d.ts
+++ b/src/types/direction.d.ts
@@ -1,0 +1,31 @@
+interface Location {
+  latitude: number;
+  longitude: number;
+}
+
+export interface PostDirectionResponse {
+  state: number;
+  result: 'success';
+  message: null;
+  data: [
+    {
+      routingProfile: pedestrian;
+      locations: Location[];
+      duration: number;
+      distance: number;
+    },
+    {
+      routingProfile: cyclability;
+      locations: Location[];
+      duration: number;
+      distance: number;
+    },
+    {
+      routingProfile: pedestrian;
+      locations: Location[];
+      duration: number;
+      distance: number;
+    }
+  ];
+  error: [];
+}


### PR DESCRIPTION
# 작업 내용

- [x] common, direction api 구현
   - fetch로 작성
   - CORS 때문에 option에 mode 속성 존재
- [x] 모든 주소 작성시 postDirection API 호출
   - api 호출시 출발지, 목적지의 위도, 경도가 필요해서 atom을 이용해 전역으로 사용했습니다.

![image](https://github.com/Team-Router/client/assets/75886763/9ad91ba6-faa9-4f47-bcc5-e2d0bf1d3057)

# 관련 이슈

- 현재 처음 api 호출 될 때는 1번 호출되지만, 이후 2번씩 호출하게 됩니다. 아마 state의 업데이트에 따라 중복으로 일어나는 듯해보이는데 미해결 상태입니다. 현재 해결중에 있으며 해결하신 분이 계시면 커밋과 알림 부탁드립니다.

# 중점적으로 봐줬으면 하는 부분

- 함수명, 변수명 적절한지 확인 부탁드립니다.
