### PR TITLE
출발 도착지에 따른 경로 선(Polyline) 구현

### DIFF
--- a/src/api/direction.ts
+++ b/src/api/direction.ts
@@ -9,6 +9,20 @@ interface PostDirectionParam {
   endLongitude: number;
 }
 
-export const getDirectionBySelectedLocation = (param: PostDirectionParam) => {
-  return postFetch('/route/cycle', param) as Promise<PostDirectionResponse>;
+export const getDirectionBySelectedLocation = ({
+  startLatitude,
+  startLongitude,
+  endLatitude,
+  endLongitude,
+}: PostDirectionParam) => {
+  return postFetch('/route/cycle', {
+    startLocation: {
+      latitude: startLatitude,
+      longitude: startLongitude,
+    },
+    endLocation: {
+      latitude: endLatitude,
+      longitude: endLongitude,
+    },
+  }) as Promise<PostDirectionResponse>;
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,3 @@
+export const SUCCESS = 'success';
+export const PEDESTRIAN = 'pedestrian';
+export const CYCLABILITY = 'cyclability';

--- a/src/types/direction.d.ts
+++ b/src/types/direction.d.ts
@@ -1,31 +1,22 @@
+import { PEDESTRIAN, CYCLABILITY } from '../constants';
+
 interface Location {
   latitude: number;
   longitude: number;
+}
+
+type RoutingProfile = PEDESTRIAN | CYCLABILITY;
+
+interface RoutingData extends RoutingProfile {
+  locations: Location[];
+  duration: number;
+  distance: number;
 }
 
 export interface PostDirectionResponse {
   state: number;
   result: 'success';
   message: null;
-  data: [
-    {
-      routingProfile: pedestrian;
-      locations: Location[];
-      duration: number;
-      distance: number;
-    },
-    {
-      routingProfile: cyclability;
-      locations: Location[];
-      duration: number;
-      distance: number;
-    },
-    {
-      routingProfile: pedestrian;
-      locations: Location[];
-      duration: number;
-      distance: number;
-    }
-  ];
+  data: RoutingData[];
   error: [];
 }


### PR DESCRIPTION
<!-- 제목 : [작업 제목] -->

# 작업 내용

<!-- 상세 설명 관련이미지 첨부 -->
<!-- 관련 이슈 번호가 있으면 작성 -->
<img width="475" alt="image" src="https://github.com/Team-Router/client/assets/50071076/f3fa03cf-3cde-4705-8395-a74937b5be19">

- [x] 보행자 파랑, 따릉이 빨간색으로 polyline 구현 
- [x] routingProfile(보행자,따릉이여부)에 따른 분기처리로 색 분리
- [x] string 타입 변수 constants(상수) 폴더로 이동

# 관련 이슈
**앞으로 구현해야할 기능**
- [ ] 출발지를 다시 선택하였을 때 경로 지우고 다시 그려야함
- [ ] 시간과 거리, 즉 얼마나 걸리고 몇키로인지 보여주어야 합니다.

**이슈**
- [ ] 의존성 배열에 모든 변수를 추가하지 않았습니다. -> 이 부분 렌더링 때문에 자주 이슈
 생기는데 우선 구현하고 리팩토링 할 때 아예 메모이제이션을 적용하는 것은 어떤가요? 우선 구현에 집중해서 속도를 따라잡아보는게 어떨까요ㅠㅠ
- [ ] 경기도 -> 서울 경유지 -> 서울 경유지 반납. => 경기도 로직
   - 이런 로직인데 무조건 따릉이를 빌리는 최적의 경로를 찾다보니까 필요없는 경유가 보이는 것 같습니당 :) (백엔드와 논의 필요)
<img width="577" alt="image" src="https://github.com/Team-Router/client/assets/50071076/a6d32623-45be-4352-89e0-c7c20975701e">


<!-- 앞으로 구현해야할 기능, 유의해야 할 점 -->
<!-- 없는 경우, 삭제 -->