### PR TITLE
대여소 실시간 조회 구현

### DIFF
--- a/src/api/direction.ts
+++ b/src/api/direction.ts
@@ -1,4 +1,4 @@
-import { PostDirectionResponse } from '@/types/direction';
+import type { PostDirectionResponse } from '@/types/direction';
 
 import { postFetch } from './common';
 

--- a/src/api/station.ts
+++ b/src/api/station.ts
@@ -1,5 +1,8 @@
-import { getFetch } from './common';
+import { postFetch } from './common';
 
-export const getAllStation = () => {
-  return getFetch('/station/realtime') as Promise<StationResponse>;
+export const getRealTimeStation = (mapCenterLocation: StationParam) => {
+  return postFetch(
+    '/station/realtime',
+    mapCenterLocation
+  ) as Promise<StationResponse>;
 };

--- a/src/api/station.ts
+++ b/src/api/station.ts
@@ -1,0 +1,5 @@
+import { getFetch } from './common';
+
+export const getAllStation = () => {
+  return getFetch('/station/realtime') as Promise<StationResponse>;
+};

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -20,13 +20,19 @@ export default function KakaoMap() {
   const polylines = useRef<kakao.maps.Polyline[]>([]);
   const resultOverlays = useRef<kakao.maps.CustomOverlay[]>([]);
 
-  const { displayMarker, displayInfoWindow, closeInfoWindow, getPosition } =
-    useKakaoMap();
+  const {
+    displayMarker,
+    displayInfoWindow,
+    closeInfoWindow,
+    getPosition,
+    getRealTimeAllStation,
+  } = useKakaoMap();
   const { initPosition } = useGeolocation();
 
   useEffect(() => {
     displayMarker(location.startLatitude, location.startLongitude, 'start');
-  }, [location, displayMarker]);
+    // getRealTimeAllStation();
+  }, [location, displayMarker, getRealTimeAllStation]);
 
   useEffect(() => {
     if (!map) {

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@mui/material';
 import { useAtom, useAtomValue } from 'jotai';
 import Script from 'next/script';
 import React, { useCallback, useEffect, useRef } from 'react';
@@ -25,14 +26,14 @@ export default function KakaoMap() {
     displayInfoWindow,
     closeInfoWindow,
     getPosition,
-    getRealTimeAllStation,
+    displayRealTimeStation,
+    closeRealTimeStationInfoWindow,
   } = useKakaoMap();
   const { initPosition } = useGeolocation();
 
   useEffect(() => {
     displayMarker(location.startLatitude, location.startLongitude, 'start');
-    // getRealTimeAllStation();
-  }, [location, displayMarker, getRealTimeAllStation]);
+  }, [location, displayMarker]);
 
   useEffect(() => {
     if (!map) {
@@ -101,8 +102,9 @@ export default function KakaoMap() {
       clearPolylines();
       clearResultOverlays();
       postDirection();
+      closeRealTimeStationInfoWindow();
     }
-  }, [address, postDirection]);
+  }, [address, postDirection, closeRealTimeStationInfoWindow]);
 
   const getPolylineOfDirection = useCallback(
     (locations: Location[], routingProfile: RoutingProfile) => {
@@ -120,12 +122,15 @@ export default function KakaoMap() {
 
   return (
     <>
+      <Button onClick={displayRealTimeStation} fullWidth>
+        현 지도에서 대여소 검색
+      </Button>
       <div
         ref={mapRef}
         id="kakao-map"
         style={{
           width: '100%',
-          height: '87%',
+          height: '83%',
         }}
       ></div>
       <Script

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -6,7 +6,7 @@ import Script from 'next/script';
 import React, { useCallback, useEffect, useRef } from 'react';
 
 import { getDirectionBySelectedLocation } from '@/api/direction';
-import { PEDESTRIAN, SUCCESS } from '@/constants';
+import { PEDESTRIAN } from '@/constants';
 import { useGeolocation } from '@/hooks/useGeolocation';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
 import { addressAtom, locationAtom, mapAtom } from '@/store/atom';
@@ -54,22 +54,24 @@ export default function KakaoMap() {
   }, [map, displayInfoWindow, closeInfoWindow]);
 
   const postDirection = useCallback(async () => {
-    const { data, result } = await getDirectionBySelectedLocation(location);
+    const { routes } = await getDirectionBySelectedLocation(location);
 
-    if (result === SUCCESS) {
-      data.forEach(({ locations, routingProfile, distance, duration }) => {
-        const polyline = getPolylineOfDirection(locations, routingProfile);
-        polyline.setMap(map);
-        polylines.current?.push(polyline);
-        displayResultOverlay(
-          locations[locations.length - 1].latitude,
-          locations[locations.length - 1].longitude,
-          distance,
-          duration,
-          routingProfile
-        );
-      });
+    if (routes.length === 0) {
+      alert('경로가 없습니다.');
     }
+
+    routes.forEach(({ locations, routingProfile, distance, duration }) => {
+      const polyline = getPolylineOfDirection(locations, routingProfile);
+      polyline.setMap(map);
+      polylines.current?.push(polyline);
+      displayResultOverlay(
+        locations[locations.length - 1].latitude,
+        locations[locations.length - 1].longitude,
+        distance,
+        duration,
+        routingProfile
+      );
+    });
   }, [location]);
 
   const clearPolylines = () => {

--- a/src/hooks/useKakaoMap.ts
+++ b/src/hooks/useKakaoMap.ts
@@ -105,7 +105,6 @@ export function useKakaoMap() {
         stationInfoWindow.close();
       }
     }
-    console.log('called', stationInfoWindows.current);
   };
 
   const displayRealTimeStation = async () => {

--- a/src/hooks/useKakaoMap.ts
+++ b/src/hooks/useKakaoMap.ts
@@ -2,7 +2,6 @@ import { useAtom, useAtomValue } from 'jotai';
 import { useCallback, useRef } from 'react';
 
 import { getRealTimeStation } from '@/api/station';
-import { SUCCESS } from '@/constants';
 import { addressAtom, locationAtom, mapAtom } from '@/store/atom';
 import { getInfoWindowElement } from '@/utils/getElement';
 
@@ -116,11 +115,11 @@ export function useKakaoMap() {
 
     const mapCenterLocation = map.getCenter();
     try {
-      const { data, result } = await getRealTimeStation({
+      const { data } = await getRealTimeStation({
         latitude: mapCenterLocation.getLat(),
         longitude: mapCenterLocation.getLng(),
       });
-      if (result !== SUCCESS) {
+      if (data.length === 0) {
         throw new Error();
       }
       stationInfoWindows.current.push(

--- a/src/hooks/useKakaoMap.ts
+++ b/src/hooks/useKakaoMap.ts
@@ -1,6 +1,8 @@
 import { useAtom, useAtomValue } from 'jotai';
 import { useCallback, useRef } from 'react';
 
+import { getAllStation } from '@/api/station';
+import { SUCCESS } from '@/constants';
 import { addressAtom, locationAtom, mapAtom } from '@/store/atom';
 import { getInfoWindowElement } from '@/utils/getElement';
 
@@ -13,6 +15,7 @@ export function useKakaoMap() {
   const startMarker = useRef<kakao.maps.Marker>();
   const endMarker = useRef<kakao.maps.Marker>();
   const infoWindow = useRef<kakao.maps.InfoWindow | null>();
+  const stationInfoWindows = useRef<kakao.maps.InfoWindow[] | null>();
 
   const getPosition = (lat: number, lon: number) => {
     return new kakao.maps.LatLng(lat, lon);
@@ -96,11 +99,35 @@ export function useKakaoMap() {
     geocoder.coord2Address(lon, lat, callback);
   };
 
+  const getRealTimeAllStation = async () => {
+    try {
+      const { data, result } = await getAllStation();
+      if (result !== SUCCESS || !map) {
+        throw new Error();
+      }
+      stationInfoWindows.current = data.map(
+        (d) =>
+          new kakao.maps.InfoWindow({
+            map,
+            position: new kakao.maps.LatLng(
+              d.stationLatitude,
+              d.stationLongitude
+            ),
+            content: `<div style="width: 100%; padding:5px;">${d.parkingBikeTotCnt}</div>`,
+          })
+      );
+      console.log(stationInfoWindows.current);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   return {
     getPosition,
     displayMarker,
     displayInfoWindow,
     closeInfoWindow,
     changeAddress,
+    getRealTimeAllStation,
   };
 }

--- a/src/types/direction.d.ts
+++ b/src/types/direction.d.ts
@@ -13,9 +13,5 @@ interface RoutingData {
 }
 
 export interface PostDirectionResponse {
-  state: number;
-  result: 'success';
-  message: null;
-  data: RoutingData[];
-  error: [];
+  routes: RoutingData[];
 }

--- a/src/types/station.d.ts
+++ b/src/types/station.d.ts
@@ -1,0 +1,15 @@
+interface StationData {
+  stationName: string;
+  parkingBikeTotCnt: number;
+  stationLatitude: number;
+  stationLongitude: number;
+  stationId: string;
+}
+
+interface StationResponse {
+  state: 200;
+  result: 'success';
+  message: null;
+  data: StationData[];
+  error: [];
+}

--- a/src/types/station.d.ts
+++ b/src/types/station.d.ts
@@ -7,11 +7,8 @@ interface StationData {
 }
 
 interface StationResponse {
-  state: 200;
-  result: 'success';
-  message: null;
+  count: number;
   data: StationData[];
-  error: [];
 }
 
 interface StationParam {

--- a/src/types/station.d.ts
+++ b/src/types/station.d.ts
@@ -13,3 +13,8 @@ interface StationResponse {
   data: StationData[];
   error: [];
 }
+
+interface StationParam {
+  latitude: number;
+  longitude: number;
+}


### PR DESCRIPTION
# 작업 내용

- [x] 대여소 실시간 조회 api 연동
- [x] 대여소 info window로 표시
   - 조회 버튼 누르면 이전 info window 제거
   - 경로 탐색시 이전 info window 제거

![image](https://github.com/Team-Router/client/assets/75886763/654e9760-a846-4c64-b096-f4040603b712)

# 관련 이슈

- 맨 처음에 조회가 되도록 하고 싶었지만, 아래 문제들을 마주해서 위와 같이 구현하였습니다.
   - 초기 infowindow가 중첩으로 대여소 표시
   - 또는 경로 탐색시 초기 위치의 대여소 표시

# 중점적으로 봐줬으면 하는 부분

- info window에 대여수를 숫자만 표현하고 싶었는데, 크기를 줄이는 방법이 (현재까지론) 없습니다. 그래서 일단 위 사진처럼 해두었는데 더 좋은 방법이 있으면 피드백 꼭 부탁드립니다.