### PR TITLE
only 걷기 경로 표시하기

### DIFF
--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,5 +1,3 @@
-const token = localStorage.getItem('token');
-
 interface Param {
   [key: string]: any;
 }
@@ -22,7 +20,7 @@ export const getFetch = (url: string, options?: RequestInit) => {
     ...options,
     mode: 'cors',
     headers: {
-      Authentication: `Bearer ${token}`,
+      // Authentication: `Bearer ${token}`,
     },
   });
 };
@@ -33,7 +31,7 @@ export const postFetch = (url: string, param: Param, options?: RequestInit) => {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authentication: `Bearer ${token}`,
+      // Authentication: `Bearer ${token}`,
     },
     mode: 'cors',
     body: JSON.stringify(param),

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { Button } from '@mui/material';
+import { Box, Button } from '@mui/material';
 import { useAtom, useAtomValue } from 'jotai';
 import Script from 'next/script';
 import React, { useCallback, useEffect, useRef } from 'react';
 
-import { getDirectionBySelectedLocation } from '@/api/direction';
+import {
+  getDirectionBySelectedLocation,
+  getWalkDirectionBySelectedLocation,
+} from '@/api/direction';
 import { PEDESTRIAN } from '@/constants';
 import { useGeolocation } from '@/hooks/useGeolocation';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
@@ -19,6 +22,7 @@ export default function KakaoMap() {
   const [map, setMap] = useAtom(mapAtom);
   const mapRef = useRef<HTMLDivElement>(null);
   const polylines = useRef<kakao.maps.Polyline[]>([]);
+  const walkPolylines = useRef<kakao.maps.Polyline[]>([]);
   const resultOverlays = useRef<kakao.maps.CustomOverlay[]>([]);
 
   const {
@@ -60,6 +64,7 @@ export default function KakaoMap() {
 
     if (getDirectionsResponses.length === 0) {
       alert('경로가 없습니다.');
+      return;
     }
 
     getDirectionsResponses.forEach(
@@ -78,9 +83,32 @@ export default function KakaoMap() {
     );
   }, [location]);
 
+  const postWalkDirection = async () => {
+    const { locations, distance, duration, routingProfile } =
+      await getWalkDirectionBySelectedLocation(location);
+
+    if (locations.length === 0) {
+      alert('경로가 없습니다.');
+      return;
+    }
+
+    const polyline = getPolylineOfDirection(locations, routingProfile);
+    polyline.setMap(map);
+    walkPolylines.current?.push(polyline);
+    displayResultOverlay(
+      locations[locations.length - 1].latitude,
+      locations[locations.length - 1].longitude,
+      distance,
+      duration,
+      routingProfile
+    );
+  };
+
   const clearPolylines = () => {
     polylines.current?.forEach((polyline) => polyline.setMap(null));
     polylines.current = [];
+    walkPolylines.current?.forEach((polyline) => polyline.setMap(null));
+    walkPolylines.current = [];
   };
 
   const displayResultOverlay = (
@@ -103,14 +131,12 @@ export default function KakaoMap() {
     resultOverlays.current = [];
   };
 
-  useEffect(() => {
-    if (address.start && address.end) {
-      clearPolylines();
-      clearResultOverlays();
-      postDirection();
-      closeRealTimeStationInfoWindow();
-    }
-  }, [address, postDirection, closeRealTimeStationInfoWindow]);
+  const searchDirection = (searchType: 'withCycle' | 'withoutCycle') => {
+    clearPolylines();
+    clearResultOverlays();
+    searchType === 'withCycle' ? postDirection() : postWalkDirection();
+    closeRealTimeStationInfoWindow();
+  };
 
   const getPolylineOfDirection = useCallback(
     (locations: LocalLocation[], routingProfile: RoutingProfile) => {
@@ -128,15 +154,49 @@ export default function KakaoMap() {
 
   return (
     <>
-      <Button onClick={displayRealTimeStation} fullWidth>
-        현 지도에서 대여소 검색
+      <Box sx={{ display: 'flex' }}>
+        <Button
+          onClick={() => searchDirection('withCycle')}
+          fullWidth
+          disabled={!(address.start && address.end)}
+        >
+          따릉이 대여 경로
+        </Button>
+        <Button
+          onClick={() => searchDirection('withoutCycle')}
+          fullWidth
+          disabled={!(address.start && address.end)}
+        >
+          걷기 경로
+        </Button>
+      </Box>
+      <Button
+        onClick={displayRealTimeStation}
+        sx={{
+          position: 'absolute',
+          width: '414px',
+          zIndex: 1,
+        }}
+      >
+        <div
+          style={{
+            background: 'white',
+            padding: '5px',
+            borderRadius: '15px',
+            opacity: '85%',
+          }}
+        >
+          현 지도에서 대여소 검색
+        </div>
       </Button>
       <div
         ref={mapRef}
         id="kakao-map"
         style={{
           width: '100%',
-          height: '83%',
+          height: '81%',
+          position: 'relative',
+          zIndex: 0,
         }}
       ></div>
       <Script


### PR DESCRIPTION
# 작업 내용

- [x] 걷기 경로 표시하기
   - 동시에 `걷자걷 경로`와 `only 걷 경로`를 보여주는 것은 결과(overlay)가 겹쳐서 좋지 않았습니다.
   - 지도 어플의 안내처럼 선택된 경로만 색상으로 표현하려하였으나 경로에 대한 이벤트를 다루는 것보다 버튼 2개로 빠른 기능 구현을 우선시하였습니다.

# 관련 이슈

- 유의점
   - `common.ts` 파일의 request-header-Authorization을 주석처리해두었습니다.

# 중점적으로 봐줬으면 하는 부분

- 버튼 2개로 처리한 것에 대한 의견을 듣고 싶습니다.
