### PR TITLE
화면 크기 상관없이 가운데 위치 및 가로길이 조절

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,12 +7,13 @@
 body {
   display: flex;
   justify-content: center;
-  width: 100wh;
+  width: 100vw;
   height: 100vh;
 }
 
 #root-layout {
-  width: 414px;
+  max-width: 414px;
+  width: 100%;
   height: 100%;
 }
 

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -174,7 +174,8 @@ export default function KakaoMap() {
         onClick={displayRealTimeStation}
         sx={{
           position: 'absolute',
-          width: '414px',
+          maxWidth: '414px',
+          width: '100%',
           zIndex: 1,
         }}
       >


### PR DESCRIPTION
# 작업 내용

- [x] 화면크기에 따라 화면이 삐져나오는 부분이 있었습니다. 버튼의 크기를 고정값으로 둬서 문제가 되었습니다.

<img width="479" alt="작업_전" src="https://github.com/Team-Router/client/assets/75886763/307f947d-1a7b-4958-97cc-0fab8d4cb3ff">

<img width="480" alt="작업_후" src="https://github.com/Team-Router/client/assets/75886763/0899b056-ed3a-422e-aac5-b257403fa8ee">


# 중점적으로 봐줬으면 하는 부분

- 본인의 핸드폰에서 이상한 점이 있다면 알려주세요~!