### PR TITLE
출발,도착 마커 이미지 변경

### DIFF
--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -37,7 +37,7 @@ export default function KakaoMap() {
 
   useEffect(() => {
     displayMarker(location.startLatitude, location.startLongitude, 'start');
-  }, [location, displayMarker]);
+  }, [location.startLatitude, location.startLongitude, displayMarker]);
 
   useEffect(() => {
     if (!map) {
@@ -130,6 +130,11 @@ export default function KakaoMap() {
     resultOverlays.current.forEach((overlay) => overlay.setMap(null));
     resultOverlays.current = [];
   };
+
+  useEffect(() => {
+    clearPolylines();
+    clearResultOverlays();
+  }, [address]);
 
   const searchDirection = (searchType: 'withCycle' | 'withoutCycle') => {
     clearPolylines();

--- a/src/hooks/useKakaoMap.ts
+++ b/src/hooks/useKakaoMap.ts
@@ -7,6 +7,11 @@ import { getInfoWindowElement } from '@/utils/getElement';
 
 type pointType = 'start' | 'end';
 
+const MARKER_START =
+  'https://github.com/Team-Router/client/assets/75886763/b1d697f6-e9d3-45a1-867f-37e2af12dc4b';
+const MARKER_END =
+  'https://github.com/Team-Router/client/assets/75886763/f32cd77f-ae9d-46e0-a659-a99215c64562';
+
 export function useKakaoMap() {
   const map = useAtomValue(mapAtom);
   const [address, setAddress] = useAtom(addressAtom);
@@ -26,11 +31,17 @@ export function useKakaoMap() {
         return;
       }
 
+      const imageSrc = pointType === 'start' ? MARKER_START : MARKER_END;
+      const imageSize = new kakao.maps.Size(42, 42);
+      const markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize);
+
       const locPosition = getPosition(lat, lon);
       const marker = new kakao.maps.Marker({
-        map: map,
         position: locPosition,
+        image: markerImage,
       });
+      marker.setMap(map);
+
       if (pointType === 'start') {
         startMarker.current?.setMap(null);
         startMarker.current = marker;


### PR DESCRIPTION
# 작업 내용

- [x] 출발, 도착 marker 이미지 변경
- [x] 도착 marker 생성시 출발 maker로 화면이 돌아가는 버그 해결

<img width="428" alt="출발_도착_마커_변경" src="https://github.com/Team-Router/client/assets/75886763/4da3be85-40fa-42dc-aa8e-459762390773">

# 중점적으로 봐줬으면 하는 부분

- marker 이미지가 정확하게 start, end 세트가 없어서 최대한 비슷한 것으로 찾아서 적용했습니다.
