### PR TITLE
즐겨찾기 추가 및 선택시 화면 이동

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^5.13.3",
+    "@mui/icons-material": "^5.14.0",
     "jotai": "^2.1.1",
     "next": "13.4.4",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@mui/icons-material": "^5.14.0",
     "@types/node": "20.2.5",
     "@types/react": "18.2.7",
     "@types/react-dom": "18.2.4",

--- a/src/api/station.ts
+++ b/src/api/station.ts
@@ -1,4 +1,4 @@
-import { StationParam, StationResponse } from '@/types/station';
+import type { StationParam, StationResponse } from '@/types/station';
 
 import { postFetch } from './common';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,21 +2,23 @@
 import DirectionsBikeIcon from '@mui/icons-material/DirectionsBike';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import { Tab, Tabs } from '@mui/material';
-import { useState } from 'react';
+import { useAtom } from 'jotai';
 
 import AddressInput from '@/components/AddressInput';
 import FavoritesTabs from '@/components/Favorites/FavoritesTab';
 import KaKaoMap from '@/components/KaKaoMap';
+import { FAVORITE, ROUTES } from '@/constants';
+import { pageTabAtom } from '@/store/atom';
 
 export default function Home() {
-  const [tabValue, setTabValue] = useState(0);
+  const [tabValue, setTabValue] = useAtom(pageTabAtom);
 
-  const handleChange = (event: React.SyntheticEvent, newTabValue: number) => {
+  const handleChange = (event: React.SyntheticEvent, newTabValue: string) => {
     setTabValue(newTabValue);
   };
 
   return (
-    <>
+    <div style={{ width: '100%', height: '100%', position: 'relative' }}>
       <Tabs
         value={tabValue}
         onChange={handleChange}
@@ -27,16 +29,38 @@ export default function Home() {
           icon={<DirectionsBikeIcon />}
           aria-label="routes"
           label="경로 찾기"
+          value={ROUTES}
         />
-        <Tab icon={<FavoriteIcon />} aria-label="favorite" label="즐겨찾기" />
+        <Tab
+          icon={<FavoriteIcon />}
+          aria-label="favorite"
+          label="즐겨찾기"
+          value={FAVORITE}
+        />
       </Tabs>
-      {tabValue === 0 && (
-        <>
-          <AddressInput />
-          <KaKaoMap />
-        </>
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          position: 'absolute',
+          zIndex: tabValue === ROUTES ? 9 : -9,
+        }}
+      >
+        <AddressInput />
+        <KaKaoMap />
+      </div>
+      {tabValue === FAVORITE && (
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            position: 'absolute',
+            zIndex: tabValue === FAVORITE ? 9 : -9,
+          }}
+        >
+          <FavoritesTabs />
+        </div>
       )}
-      {tabValue === 1 && <FavoritesTabs />}
-    </>
+    </div>
   );
 }

--- a/src/components/Favorites/FavoritesTab.tsx
+++ b/src/components/Favorites/FavoritesTab.tsx
@@ -18,7 +18,7 @@ export default function FavoritesTab() {
   };
 
   return (
-    <>
+    <div style={{ width: '100%', height: '100%', backgroundColor: 'white' }}>
       <Tabs
         value={tabValue}
         onChange={handleTabChange}
@@ -30,6 +30,6 @@ export default function FavoritesTab() {
       </Tabs>
       {tabValue === STATION && <Station />}
       {tabValue === PLACE && <Place />}
-    </>
+    </div>
   );
 }

--- a/src/components/Favorites/Place.tsx
+++ b/src/components/Favorites/Place.tsx
@@ -4,32 +4,63 @@ import HomeIcon from '@mui/icons-material/Home';
 import MapsHomeWorkIcon from '@mui/icons-material/MapsHomeWork';
 import {
   Avatar,
+  Button,
   List,
   ListItem,
   ListItemAvatar,
   ListItemText,
 } from '@mui/material';
+import { useSetAtom } from 'jotai';
+import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 
 import { getAllFavoritePlace } from '@/api/favorite';
+import { ROUTES } from '@/constants';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { pageTabAtom } from '@/store/atom';
+import type { MoveToLocationParam } from '@/types/direction';
 import type { Place } from '@/types/favorite';
 
 export default function Place() {
-  const { changeAddressWithGeocoder } = useKakaoMap();
+  const setTabValue = useSetAtom(pageTabAtom);
+  const { changeAddressWithGeocoder, moveToLocation } = useKakaoMap();
   const [favoritePlaces, setFavoritePlaces] = useState<Place[]>([]);
-  const [accessToken, setAccessToken] = useLocalStorage('accessToken', null);
+  const [accessToken] = useLocalStorage('accessToken', null);
 
   useEffect(() => {
     try {
-      getFavoritePlaces();
+      if (accessToken) {
+        getFavoritePlaces();
+      }
     } catch (e) {
       console.error(e);
     }
   }, []);
 
+  if (!accessToken) {
+    return (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <Link href={'/oauth'}>
+          <Button>로그인 먼저 바랍니다.</Button>
+        </Link>
+      </div>
+    );
+  }
+
   const getFavoritePlaces = async () => {
+    if (!accessToken) {
+      return;
+    }
+
     const stations = await getAllFavoritePlace(accessToken);
     setFavoritePlaces(
       stations.favoritePlaces.map((place: Place) => {
@@ -45,20 +76,40 @@ export default function Place() {
     return address;
   };
 
+  const favoritePlackClickHandler = (latitude: number, longitude: number) => {
+    const param: MoveToLocationParam = { latitude, longitude, type: 'start' };
+    const isStart = window.confirm('출발지로 설정할까요?');
+    if (!isStart) {
+      const isEnd = window.confirm('도착지로 설정할까요?');
+      if (!isEnd) {
+        return;
+      }
+      param.type = 'end';
+    }
+    setTabValue(ROUTES);
+    moveToLocation(param);
+  };
+
   return (
     <List>
-      {favoritePlaces.map(({ id, name, address }, index) => (
-        <ListItem key={`${name}-${id}-${index}`}>
-          <ListItemAvatar>
-            <Avatar>
-              {name === 'HOME' && <HomeIcon />}
-              {name === 'OFFICE' && <BusinessIcon />}
-              {name === 'NORMAL' && <MapsHomeWorkIcon />}
-            </Avatar>
-          </ListItemAvatar>
-          <ListItemText primary={address} />
-        </ListItem>
-      ))}
+      {favoritePlaces.map(
+        ({ id, name, address, latitude, longitude }, index) => (
+          <ListItem
+            key={`${name}-${id}-${index}`}
+            style={{ cursor: 'pointer' }}
+            onClick={() => favoritePlackClickHandler(latitude, longitude)}
+          >
+            <ListItemAvatar>
+              <Avatar>
+                {name === 'HOME' && <HomeIcon />}
+                {name === 'OFFICE' && <BusinessIcon />}
+                {name === 'NORMAL' && <MapsHomeWorkIcon />}
+              </Avatar>
+            </ListItemAvatar>
+            <ListItemText primary={address} />
+          </ListItem>
+        )
+      )}
     </List>
   );
 }

--- a/src/components/Favorites/Place.tsx
+++ b/src/components/Favorites/Place.tsx
@@ -18,13 +18,16 @@ import { getAllFavoritePlace } from '@/api/favorite';
 import { END, ROUTES, START } from '@/constants';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
-import { pageTabAtom } from '@/store/atom';
+import { moveToLocationGlobalParamAtom, pageTabAtom } from '@/store/atom';
 import type { MoveToLocationParam } from '@/types/direction';
 import type { Place } from '@/types/favorite';
 
 export default function Place() {
   const setTabValue = useSetAtom(pageTabAtom);
-  const { changeAddressWithGeocoder, moveToLocation } = useKakaoMap();
+  const setMoveToLocationGlobalParam = useSetAtom(
+    moveToLocationGlobalParamAtom
+  );
+  const { changeAddressWithGeocoder } = useKakaoMap();
   const [favoritePlaces, setFavoritePlaces] = useState<Place[]>([]);
   const [accessToken] = useLocalStorage('accessToken', null);
 
@@ -87,7 +90,7 @@ export default function Place() {
       param.type = END;
     }
     setTabValue(ROUTES);
-    moveToLocation(param);
+    setMoveToLocationGlobalParam(param);
   };
 
   return (

--- a/src/components/Favorites/Place.tsx
+++ b/src/components/Favorites/Place.tsx
@@ -15,7 +15,7 @@ import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 
 import { getAllFavoritePlace } from '@/api/favorite';
-import { ROUTES } from '@/constants';
+import { END, ROUTES, START } from '@/constants';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { pageTabAtom } from '@/store/atom';
@@ -50,7 +50,7 @@ export default function Place() {
         }}
       >
         <Link href={'/oauth'}>
-          <Button>로그인 먼저 바랍니다.</Button>
+          <Button>로그인하러 가기</Button>
         </Link>
       </div>
     );
@@ -77,14 +77,14 @@ export default function Place() {
   };
 
   const favoritePlackClickHandler = (latitude: number, longitude: number) => {
-    const param: MoveToLocationParam = { latitude, longitude, type: 'start' };
+    const param: MoveToLocationParam = { latitude, longitude, type: START };
     const isStart = window.confirm('출발지로 설정할까요?');
     if (!isStart) {
       const isEnd = window.confirm('도착지로 설정할까요?');
       if (!isEnd) {
         return;
       }
-      param.type = 'end';
+      param.type = END;
     }
     setTabValue(ROUTES);
     moveToLocation(param);

--- a/src/components/Favorites/Station.tsx
+++ b/src/components/Favorites/Station.tsx
@@ -13,7 +13,7 @@ import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 
 import { getFavoriteAllStation } from '@/api/favorite';
-import { ROUTES } from '@/constants';
+import { ROUTES, STATION } from '@/constants';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { pageTabAtom } from '@/store/atom';
@@ -47,7 +47,7 @@ export default function Station() {
         }}
       >
         <Link href={'/oauth'}>
-          <Button>로그인 먼저 바랍니다.</Button>
+          <Button>로그인하러 가기</Button>
         </Link>
       </div>
     );
@@ -74,7 +74,7 @@ export default function Station() {
 
   const favoriteStationClickHandler = (latitude: number, longitude: number) => {
     setTabValue(ROUTES);
-    moveToLocation({ latitude, longitude, type: 'station' });
+    moveToLocation({ latitude, longitude, type: STATION });
   };
 
   return (

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -12,13 +12,19 @@ import {
 import { PEDESTRIAN, START } from '@/constants';
 import { useGeolocation } from '@/hooks/useGeolocation';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
-import { addressAtom, locationAtom, mapAtom } from '@/store/atom';
+import {
+  addressAtom,
+  locationAtom,
+  mapAtom,
+  moveToLocationGlobalParamAtom,
+} from '@/store/atom';
 import type { LocalLocation, RoutingProfile } from '@/types/direction';
 import { getResultOverlayElement } from '@/utils/getElement';
 
 export default function KakaoMap() {
   const address = useAtomValue(addressAtom);
   const location = useAtomValue(locationAtom);
+  const moveToLocationGlobalParam = useAtomValue(moveToLocationGlobalParamAtom);
   const [map, setMap] = useAtom(mapAtom);
   const mapRef = useRef<HTMLDivElement>(null);
   const polylines = useRef<kakao.maps.Polyline[]>([]);
@@ -32,12 +38,20 @@ export default function KakaoMap() {
     getPosition,
     displayRealTimeStation,
     closeRealTimeStationInfoWindow,
+    moveToLocation,
   } = useKakaoMap();
   const { initPosition } = useGeolocation();
 
   useEffect(() => {
     displayMarker(location.startLatitude, location.startLongitude, START);
   }, [location.startLatitude, location.startLongitude, displayMarker]);
+
+  useEffect(() => {
+    const { latitude, longitude, type } = moveToLocationGlobalParam;
+    if (latitude && longitude && type) {
+      moveToLocation({ latitude, longitude, type });
+    }
+  }, [moveToLocationGlobalParam]);
 
   useEffect(() => {
     if (!map) {

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -9,7 +9,7 @@ import {
   getDirectionBySelectedLocation,
   getWalkDirectionBySelectedLocation,
 } from '@/api/direction';
-import { PEDESTRIAN } from '@/constants';
+import { PEDESTRIAN, START } from '@/constants';
 import { useGeolocation } from '@/hooks/useGeolocation';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
 import { addressAtom, locationAtom, mapAtom } from '@/store/atom';
@@ -36,7 +36,7 @@ export default function KakaoMap() {
   const { initPosition } = useGeolocation();
 
   useEffect(() => {
-    displayMarker(location.startLatitude, location.startLongitude, 'start');
+    displayMarker(location.startLatitude, location.startLongitude, START);
   }, [location.startLatitude, location.startLongitude, displayMarker]);
 
   useEffect(() => {

--- a/src/components/KaKaoMap.tsx
+++ b/src/components/KaKaoMap.tsx
@@ -13,7 +13,7 @@ import { PEDESTRIAN } from '@/constants';
 import { useGeolocation } from '@/hooks/useGeolocation';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
 import { addressAtom, locationAtom, mapAtom } from '@/store/atom';
-import { LocalLocation, RoutingProfile } from '@/types/direction';
+import type { LocalLocation, RoutingProfile } from '@/types/direction';
 import { getResultOverlayElement } from '@/utils/getElement';
 
 export default function KakaoMap() {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,14 @@
 export const SUCCESS = 'success';
 export const PEDESTRIAN = 'pedestrian';
 export const CYCLABILITY = 'cyclability';
+
 export const STATION = 'station';
 export const PLACE = 'place';
+
+export const ROUTES = 'routes';
+export const FAVORITE = 'favorite';
+
+export const MARKER_START =
+  'https://github.com/Team-Router/client/assets/75886763/b1d697f6-e9d3-45a1-867f-37e2af12dc4b';
+export const MARKER_END =
+  'https://github.com/Team-Router/client/assets/75886763/f32cd77f-ae9d-46e0-a659-a99215c64562';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -8,6 +8,9 @@ export const PLACE = 'place';
 export const ROUTES = 'routes';
 export const FAVORITE = 'favorite';
 
+export const START = 'start';
+export const END = 'end';
+
 export const MARKER_START =
   'https://github.com/Team-Router/client/assets/75886763/b1d697f6-e9d3-45a1-867f-37e2af12dc4b';
 export const MARKER_END =

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -1,6 +1,7 @@
 import { useAtom } from 'jotai';
 import { useCallback } from 'react';
 
+import { START } from '@/constants';
 import { locationAtom } from '@/store/atom';
 
 import { useKakaoMap } from './useKakaoMap';
@@ -18,7 +19,7 @@ export function useGeolocation() {
           startLatitude: latitude,
           startLongitude: longitude,
         });
-        changeAddress(latitude, longitude, 'start');
+        changeAddress(latitude, longitude, START);
       });
     } else {
       alert('현위치를 알 수 없습니다.');

--- a/src/hooks/useKakaoMap.ts
+++ b/src/hooks/useKakaoMap.ts
@@ -5,13 +5,7 @@ import { useCallback, useRef } from 'react';
 import { addFavoritePlace, addFavoriteStation } from '@/api/favorite';
 import { getRealTimeStation } from '@/api/station';
 import { END, MARKER_END, MARKER_START, START, STATION } from '@/constants';
-import {
-  addressAtom,
-  endMarkerAtom,
-  locationAtom,
-  mapAtom,
-  startMarkerAtom,
-} from '@/store/atom';
+import { addressAtom, locationAtom, mapAtom } from '@/store/atom';
 import type { MoveToLocationParam, pointType } from '@/types/direction';
 import type { StationData } from '@/types/station';
 import { getButtonElement, getInfoWindowElement } from '@/utils/getElement';
@@ -23,8 +17,8 @@ export function useKakaoMap() {
   const map = useAtomValue(mapAtom);
   const [address, setAddress] = useAtom(addressAtom);
   const [location, setLocation] = useAtom(locationAtom);
-  const [startMarker, setStartMarker] = useAtom(startMarkerAtom);
-  const [endMarker, setEndMarker] = useAtom(endMarkerAtom);
+  const startMarker = useRef<kakao.maps.Marker>();
+  const endMarker = useRef<kakao.maps.Marker>();
   const [accessToken] = useLocalStorage('accessToken', null);
   const infoWindow = useRef<kakao.maps.InfoWindow | null>();
   const stationInfoWindows = useRef<kakao.maps.InfoWindow[]>([]);
@@ -50,12 +44,12 @@ export function useKakaoMap() {
       });
 
       if (pointType === START) {
-        startMarker?.setMap(null);
-        setStartMarker(marker);
+        startMarker.current?.setMap(null);
+        startMarker.current = marker;
       }
       if (pointType === END) {
-        endMarker?.setMap(null);
-        setEndMarker(marker);
+        endMarker.current?.setMap(null);
+        endMarker.current = marker;
       }
       console.log(startMarker, endMarker);
       marker.setMap(map);

--- a/src/hooks/useKakaoMap.ts
+++ b/src/hooks/useKakaoMap.ts
@@ -4,7 +4,7 @@ import { useCallback, useRef } from 'react';
 
 import { addFavoritePlace, addFavoriteStation } from '@/api/favorite';
 import { getRealTimeStation } from '@/api/station';
-import { MARKER_END, MARKER_START } from '@/constants';
+import { END, MARKER_END, MARKER_START, START, STATION } from '@/constants';
 import {
   addressAtom,
   endMarkerAtom,
@@ -39,7 +39,7 @@ export function useKakaoMap() {
         return;
       }
 
-      const imageSrc = pointType === 'start' ? MARKER_START : MARKER_END;
+      const imageSrc = pointType === START ? MARKER_START : MARKER_END;
       const imageSize = new kakao.maps.Size(42, 42);
       const markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize);
 
@@ -49,11 +49,11 @@ export function useKakaoMap() {
         image: markerImage,
       });
 
-      if (pointType === 'start') {
+      if (pointType === START) {
         startMarker?.setMap(null);
         setStartMarker(marker);
       }
-      if (pointType === 'end') {
+      if (pointType === END) {
         endMarker?.setMap(null);
         setEndMarker(marker);
       }
@@ -82,9 +82,9 @@ export function useKakaoMap() {
         displayMarker(lat, lon, pointType);
         changeAddress(lat, lon, pointType);
         closeInfoWindow();
-        pointType === 'start' &&
+        pointType === START &&
           setLocation({ ...location, startLatitude: lat, startLongitude: lon });
-        pointType === 'end' &&
+        pointType === END &&
           setLocation({ ...location, endLatitude: lat, endLongitude: lon });
       };
     };
@@ -111,8 +111,8 @@ export function useKakaoMap() {
     };
 
     const iwContent = getInfoWindowElement(
-      makeHandler('start'),
-      makeHandler('end'),
+      makeHandler(START),
+      makeHandler(END),
       addFavoritePlaceHandler
     );
     const iwPosition = getPosition(lat, lon);
@@ -129,8 +129,8 @@ export function useKakaoMap() {
     const callback = (result: any, status: kakao.maps.services.Status) => {
       if (status === kakao.maps.services.Status.OK) {
         const newAddress = result[0].address.address_name;
-        pointType === 'start' && setAddress({ ...address, start: newAddress });
-        pointType === 'end' && setAddress({ ...address, end: newAddress });
+        pointType === START && setAddress({ ...address, start: newAddress });
+        pointType === END && setAddress({ ...address, end: newAddress });
       } else {
         alert('현재 위치의 주소를 가져올 수 없습니다.');
       }
@@ -231,22 +231,25 @@ export function useKakaoMap() {
     }
 
     const locPosition = getPosition(latitude, longitude);
-    if (type === 'station') {
+    if (type === STATION) {
       map.panTo(locPosition);
       return;
     }
 
-    type === 'start'
-      ? setLocation({
-          ...location,
-          startLatitude: latitude,
-          startLongitude: longitude,
-        })
-      : setLocation({
-          ...location,
-          endLatitude: latitude,
-          endLongitude: longitude,
-        });
+    if (type === START) {
+      setLocation({
+        ...location,
+        startLatitude: latitude,
+        startLongitude: longitude,
+      });
+    }
+    if (type === END) {
+      setLocation({
+        ...location,
+        endLatitude: latitude,
+        endLongitude: longitude,
+      });
+    }
     displayMarker(latitude, longitude, type);
     changeAddress(latitude, longitude, type);
   };

--- a/src/store/atom.ts
+++ b/src/store/atom.ts
@@ -1,5 +1,7 @@
 import { atom } from 'jotai';
 
+import { ROUTES } from '@/constants';
+
 export const mapAtom = atom<kakao.maps.Map | null>(null);
 
 export const addressAtom = atom<{ start: string; end: string }>({
@@ -18,3 +20,5 @@ export const locationAtom = atom<{
   endLatitude: 33.450701,
   endLongitude: 126.570667,
 });
+
+export const pageTabAtom = atom<string>(ROUTES);

--- a/src/store/atom.ts
+++ b/src/store/atom.ts
@@ -22,3 +22,6 @@ export const locationAtom = atom<{
 });
 
 export const pageTabAtom = atom<string>(ROUTES);
+
+export const startMarkerAtom = atom<kakao.maps.Marker | null>(null);
+export const endMarkerAtom = atom<kakao.maps.Marker | null>(null);

--- a/src/store/atom.ts
+++ b/src/store/atom.ts
@@ -1,6 +1,7 @@
 import { atom } from 'jotai';
 
 import { ROUTES } from '@/constants';
+import { MoveToLocationParam } from '@/types/direction';
 
 export const mapAtom = atom<kakao.maps.Map | null>(null);
 
@@ -25,3 +26,7 @@ export const pageTabAtom = atom<string>(ROUTES);
 
 export const startMarkerAtom = atom<kakao.maps.Marker | null>(null);
 export const endMarkerAtom = atom<kakao.maps.Marker | null>(null);
+
+export const moveToLocationGlobalParamAtom = atom<Partial<MoveToLocationParam>>(
+  {}
+);

--- a/src/types/direction.ts
+++ b/src/types/direction.ts
@@ -21,6 +21,7 @@ export interface PostWalkDirectionResponse extends RoutingData {
 }
 
 export type pointType = 'start' | 'end';
+
 export interface MoveToLocationParam {
   latitude: number;
   longitude: number;

--- a/src/types/direction.ts
+++ b/src/types/direction.ts
@@ -19,3 +19,10 @@ export interface PostDirectionResponse {
 export interface PostWalkDirectionResponse extends RoutingData {
   routingProfile: 'pedestrian';
 }
+
+export type pointType = 'start' | 'end';
+export interface MoveToLocationParam {
+  latitude: number;
+  longitude: number;
+  type: 'station' | pointType;
+}

--- a/src/types/station.ts
+++ b/src/types/station.ts
@@ -1,4 +1,4 @@
-interface StationData {
+export interface StationData {
   name: string;
   count: number;
   latitude: number;

--- a/src/utils/getElement.ts
+++ b/src/utils/getElement.ts
@@ -3,7 +3,7 @@ import type { RoutingProfile } from '@/types/direction';
 type handler = () => void;
 
 // infoWindowElement
-const getButtonElement = (text: string, handler: handler) => {
+export const getButtonElement = (text: string, handler: handler) => {
   const $button = document.createElement('button');
   $button.innerText = text;
   $button.addEventListener('click', handler);
@@ -12,11 +12,13 @@ const getButtonElement = (text: string, handler: handler) => {
 
 export const getInfoWindowElement = (
   startHandler: handler,
-  endHandler: handler
+  endHandler: handler,
+  addHandler: handler
 ) => {
   const $div = document.createElement('div');
   $div.appendChild(getButtonElement('출발', startHandler));
   $div.appendChild(getButtonElement('도착', endHandler));
+  $div.appendChild(getButtonElement('+', addHandler));
   return $div;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,7 +944,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.11.2", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.22.5", "@babel/runtime@^7.8.4":
   version "7.22.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
   integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
@@ -958,12 +958,30 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.22.5":
-  version "7.22.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
-  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
+"@babel/template@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.5.tgz#0c8c4d944509875849bd0344ff0050756eefc6ec"
+  integrity sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==
   dependencies:
-    regenerator-runtime "^0.13.11"
+    "@babel/code-frame" "^7.22.5"
+    "@babel/parser" "^7.22.5"
+    "@babel/types" "^7.22.5"
+
+"@babel/traverse@^7.22.6", "@babel/traverse@^7.22.8":
+  version "7.22.8"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.8.tgz#4d4451d31bc34efeae01eac222b514a77aa4000e"
+  integrity sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==
+  dependencies:
+    "@babel/code-frame" "^7.22.5"
+    "@babel/generator" "^7.22.7"
+    "@babel/helper-environment-visitor" "^7.22.5"
+    "@babel/helper-function-name" "^7.22.5"
+    "@babel/helper-hoist-variables" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/parser" "^7.22.7"
+    "@babel/types" "^7.22.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
 
 "@babel/types@^7.21.4":
   version "7.22.4"


### PR DESCRIPTION
# 작업 내용

- [x] 경로찾기, 즐겨찾기 탭 전환시 지도 초기화되는 버그 해결
- [x] 로그인 되지 않은 경우 화면 이동 버튼 구현
   - `access token`이 `localstorage`에 존재 여부로만 판단
- [x] 즐겨찾기 추가 기능 구현
   - 대여소, 장소 모두 가능
- [x] 즐겨찾기 대여소 클릭시 해당 위치로 지도 이동
- [x] 즐겨찾기 장소 클릭시 아래 기능 구현
   - 출발지, 도착지 구분하는 `window.confirm`으로 받기
   - 해당 장소로 지도 이동
   - 해당 장소에 출발지 또는 도착지 아이콘 표시

# 관련 이슈

- 현재 해결중에 있습니다. => 해결 완료
~~현재 출발지, 도착지의 마커값을 `null`값으로 갖는 버그가 생겨서 기존 마커가 사라지지 않습니다.
화면 등장하고 즐겨찾기 장소의 클릭으로만 출발지, 도착지를 선택한다면 정상동작합니다.
그러나 지도에 직접 마우스 클릭으로 출발지, 도착지를 선택하는 순간부터 출발지, 도착지의 전역상태값이 계속 `null`로 처리되어 새로운 마커를 찍을때 `기존 마커`를 삭제 못하는 상황입니다.
제 브랜치로 옮겨서 문제 해결에 동참하신다면 매우 감사드리겠습니다.~~
